### PR TITLE
⚡ Optimize Video component loading and autoplay

### DIFF
--- a/src/components/Video.astro
+++ b/src/components/Video.astro
@@ -11,10 +11,10 @@ const { host, source, credit, autoplay = false } = Astro.props;
 let url: string;
 switch (host) {
   case 'youtube':
-    url = `https://www.youtube.com/embed/${source}?autoplay=${autoplay ? '1' : '0'}&loop=0&controls=0&modestbranding=1`;
+    url = `https://www.youtube.com/embed/${source}?autoplay=${autoplay ? '1' : '0'}&mute=${autoplay ? '1' : '0'}&loop=0&controls=0&modestbranding=1`;
     break;
   case 'vimeo':
-    url = `https://player.vimeo.com/video/${source}?autoplay=${autoplay ? '1' : '0'}&loop=0&title=0&byline=0&portrait=0`;
+    url = `https://player.vimeo.com/video/${source}?autoplay=${autoplay ? '1' : '0'}&muted=${autoplay ? '1' : '0'}&loop=0&title=0&byline=0&portrait=0`;
     break;
 }
 ---
@@ -26,7 +26,7 @@ switch (host) {
       allow="autoplay; encrypted-media" 
       frameborder="0" 
       class="absolute top-0 left-0 w-full h-full border-0" 
-      loading="lazy"
+      loading={autoplay ? 'eager' : 'lazy'}
     ></iframe>
   </div>
   {credit && (


### PR DESCRIPTION
*   💡 **What:**
    *   Updated `src/components/Video.astro` to set `loading="eager"` when `autoplay={true}`.
    *   Added `mute=1` (YouTube) and `muted=1` (Vimeo) to URL parameters when `autoplay` is enabled.
*   🎯 **Why:**
    *   Autoplay videos should not be lazy-loaded, as this delays the start of playback, especially for LCP candidates.
    *   Modern browsers block autoplay with sound; muting ensures the video actually plays.
*   📊 **Measured Improvement:**
    *   Baseline: Autoplay videos had `loading="lazy"` and no mute params.
    *   Improvement: Autoplay videos now have `loading="eager"` and proper mute params, ensuring immediate loading and successful playback. Verified via generated HTML inspection.

---
*PR created automatically by Jules for task [17024338697672020145](https://jules.google.com/task/17024338697672020145) started by @xmflsct*