### PR TITLE
⚡ Remove inline onclick handlers for better performance and CSP

### DIFF
--- a/src/components/Tile.astro
+++ b/src/components/Tile.astro
@@ -15,7 +15,6 @@ const { url, title, tags } = Astro.props;
   <a href={url} class="group border-none text-lg">{title}</a>
   {tags.map((tag) => (
     <button
-      onclick={`checkTags('${tag}')`}
       data-tag={tag}
       class="border border-stone-600 text-stone-600 hover:border-highlight hover:bg-highlight hover:text-stone-100 transition-colors text-xs py-0.5 px-2 rounded-full"
     >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -119,12 +119,19 @@ for (const year of sortedYears) {
     window.onload = () => selectTags();
     window.onhashchange = () => selectTags();
 
-    (window as any).checkTags = function(tags: string) {
-      if (tags === window.location.hash.slice(1)) {
-        window.location.assign("#");
-      } else {
-        window.location.assign(`#${tags}`);
+    document.addEventListener('click', (event) => {
+      const target = event.target as HTMLElement;
+      const button = target.closest('button[data-tag]');
+      if (button) {
+        const tag = (button as HTMLElement).dataset.tag;
+        if (tag) {
+          if (tag === window.location.hash.slice(1)) {
+            window.location.assign("#");
+          } else {
+            window.location.assign(`#${tag}`);
+          }
+        }
       }
-    };
+    });
   </script>
 </Base>


### PR DESCRIPTION
*   💡 **What:** Replaced inline `onclick` handlers in `Tile.astro` with global event delegation in `index.astro`.
*   🎯 **Why:** Improves performance by reducing function creation/parsing overhead and enhances security/architecture by removing inline JavaScript, making the code more CSP-friendly.
*   📊 **Measured Improvement:** Verified functionality remains identical via automated script. Architectural performance is improved by decoupling logic from markup.

---
*PR created automatically by Jules for task [1171898494247069090](https://jules.google.com/task/1171898494247069090) started by @xmflsct*