### PR TITLE
⚡ Optimize tag filtering in index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -99,11 +99,16 @@ for (const year of sortedYears) {
           }
         }
       }
+      const tag = window.location.hash.slice(1);
+      const isTagPresent = tag.length > 0;
+      const startPattern = tag + ',';
+      const endPattern = ',' + tag;
+      const midPattern = ',' + tag + ',';
+
       document.querySelectorAll('.case-tile').forEach(function(tile) {
-        const tag = window.location.hash.slice(1);
         const tags = (tile as HTMLElement).dataset.tags || '';
-        if (tag.length > 0) {
-          if (tags.split(',').includes(tag)) {
+        if (isTagPresent) {
+          if (tags === tag || tags.startsWith(startPattern) || tags.endsWith(endPattern) || tags.includes(midPattern)) {
             tile.classList.remove('opacity-40');
             selected(tile, tag);
           } else {


### PR DESCRIPTION
Optimized the client-side tag filtering logic in `src/pages/index.astro` to avoid allocating a new array for every tile on every filter operation. By using string search with pre-calculated patterns, we significantly reduce the overhead of the filtering loop. Confirmed functionality with frontend verification script.

---
*PR created automatically by Jules for task [5084079768445574446](https://jules.google.com/task/5084079768445574446) started by @xmflsct*